### PR TITLE
Add `taro` to docker setup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,6 +38,20 @@ services:
       links:
         - "btcd:blockchain"
 
+    tarod:
+      image: tarod
+      container_name: tarod
+      build:
+        context: tarod/
+      environment:
+        - NETWORK
+        - DEBUG
+      volumes:
+        - lnd:/root/.lnd
+      entrypoint: [ "./start-tarod.sh" ]
+      links:
+        - "lnd:lnd"
+
 volumes:
   # shared volume is need to store the btcd rpc certificates and use it within
   # btcctl and lnd containers.

--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -66,6 +66,6 @@ exec lnd \
     "--$BACKEND.rpcpass"="$RPCPASS" \
     "--rpclisten=$HOSTNAME:10009" \
     "--rpclisten=localhost:10009" \
-    --debuglevel="$DEBUG" \
-    --tlsextraip 127.0.0.1 \
+    "--debuglevel"="$DEBUG" \
+    "--tlsextradomain"="lnd" \
     "$@"

--- a/docker/tarod/Dockerfile
+++ b/docker/tarod/Dockerfile
@@ -24,6 +24,7 @@ RUN apk --no-cache add \
 
 # Copy the compiled binaries from the builder image.
 COPY --from=builder /go/bin/tarod /bin/
+COPY --from=builder /go/bin/tarocli /bin/
 
 COPY "start-tarod.sh" .
 

--- a/docker/tarod/Dockerfile
+++ b/docker/tarod/Dockerfile
@@ -1,0 +1,34 @@
+# tarod --network=testnet --debuglevel=debug --lnd.host=localhost:10009 --lnd.macaroonpath=~/.lnd/data/chain/bitcoin/testnet/admin.macaroon --lnd.tlspath=~/.lnd/tls.cert
+
+FROM golang:1.19-alpine as builder
+
+LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
+
+# Install build dependencies such as git and glide.
+RUN apk add --no-cache git gcc musl-dev
+
+WORKDIR $GOPATH/src/github.com/lightninglabs/taro
+
+RUN git clone https://github.com/lightninglabs/taro.git . \
+    && go install ./cmd/...
+
+# Start a new image
+FROM alpine as final
+
+RUN apk --no-cache add \
+    bash \
+    jq \
+    ca-certificates \
+    gnupg \
+    curl
+
+# Copy the compiled binaries from the builder image.
+COPY --from=builder /go/bin/tarod /bin/
+
+COPY "start-tarod.sh" .
+
+RUN chmod +x start-tarod.sh
+
+VOLUME /root/.lnd
+
+ENTRYPOINT ["start-tarod.sh"]

--- a/docker/tarod/start-tarod.sh
+++ b/docker/tarod/start-tarod.sh
@@ -39,33 +39,18 @@ set_default() {
 }
 
 # Set default variables if needed.
-RPCUSER=$(set_default "$RPCUSER" "devuser")
-RPCPASS=$(set_default "$RPCPASS" "devpass")
 DEBUG=$(set_default "$DEBUG" "debug")
 NETWORK=$(set_default "$NETWORK" "simnet")
-CHAIN=$(set_default "$CHAIN" "bitcoin")
-BACKEND="btcd"
-HOSTNAME=$(hostname)
-if [[ "$CHAIN" == "litecoin" ]]; then
-    BACKEND="ltcd"
-fi
 
 # CAUTION: DO NOT use the --noseedback for production/mainnet setups, ever!
 # Also, setting --rpclisten to $HOSTNAME will cause it to listen on an IP
 # address that is reachable on the internal network. If you do this outside of
 # docker, this might be a security concern!
 
-exec lnd \
-    --noseedbackup \
-    "--$CHAIN.active" \
-    "--$CHAIN.$NETWORK" \
-    "--$CHAIN.node"="$BACKEND" \
-    "--$BACKEND.rpccert"="/rpc/rpc.cert" \
-    "--$BACKEND.rpchost"="blockchain" \
-    "--$BACKEND.rpcuser"="$RPCUSER" \
-    "--$BACKEND.rpcpass"="$RPCPASS" \
-    "--rpclisten=$HOSTNAME:10009" \
-    "--rpclisten=localhost:10009" \
-    --debuglevel="$DEBUG" \
-    --tlsextraip 127.0.0.1 \
+exec tarod \
+    "--network"="$NETWORK" \
+    "--debuglevel"="$DEBUG" \
+    "--lnd.host"="lnd:10009" \
+    "--lnd.macaroonpath"="/root/.lnd/data/chain/bitcoin/$NETWORK/admin.macaroon" \
+    "--lnd.tlspath"="/root/.lnd/tls.cert" \
     "$@"

--- a/docker/tarod/start-tarod.sh
+++ b/docker/tarod/start-tarod.sh
@@ -42,15 +42,10 @@ set_default() {
 DEBUG=$(set_default "$DEBUG" "debug")
 NETWORK=$(set_default "$NETWORK" "simnet")
 
-# CAUTION: DO NOT use the --noseedback for production/mainnet setups, ever!
-# Also, setting --rpclisten to $HOSTNAME will cause it to listen on an IP
-# address that is reachable on the internal network. If you do this outside of
-# docker, this might be a security concern!
-
 exec tarod \
     "--network"="$NETWORK" \
     "--debuglevel"="$DEBUG" \
-    "--lnd.host"="lnd:10009" \
+    "--lnd.host"="172.19.0.3:10009" \
     "--lnd.macaroonpath"="/root/.lnd/data/chain/bitcoin/$NETWORK/admin.macaroon" \
     "--lnd.tlspath"="/root/.lnd/tls.cert" \
     "$@"


### PR DESCRIPTION
Does not work yet, keep running into this error when `tarod` starts up:

```
tarod  | 2022-10-12 02:26:45.717 [WRN] CONF: open /root/.taro/taro.conf: no such file or directory
tarod  | 2022-10-12 02:26:45.718 [INF] CONF: Generating TLS certificates...
tarod  | 2022-10-12 02:26:45.719 [INF] CONF: Done generating TLS certificates
tarod  | 2022-10-12 02:26:45.720 [INF] CONF: Opening sqlite3 database at: /root/.taro/data/simnet/taro.db
tarod  | 2022-10-12 02:26:45.768 [INF] CONF: Attempting to establish connection to lnd...
tarod  | error creating server: unable to connect to lnd node: error subscribing to lnd wallet state: lnd version incompatible, need at least v0.13.0-beta, got error on state subscription: rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: x509: certificate is valid for 0f50ed7a328f, localhost, unix, unixpacket, bufconn, not lnd"
tarod exited with code 1
```

But the lnd version I'm running is:

```
$ docker exec -it lnd lnd --version
lnd version 0.15.99-beta commit=tor/v1.1.0-77-gffa8ba8df-dirty
```